### PR TITLE
Highlight 'floats' as a numeric constant.

### DIFF
--- a/Racket.JSON-tmLanguage
+++ b/Racket.JSON-tmLanguage
@@ -25,6 +25,9 @@
     {"name": "constant.numeric.integer.source.racket",
      "match": "\\b(0|([1-9][0-9_]*))\\b"
     },
+    {"name": "constant.numeric.float.source.racket",
+     "match": "\\b(0|([1-9][0-9]*))\\.([0-9]+)\\b"
+    },
     {"name": "comment.line.documentation.source.racket",
      "begin": ";",
      "end": "$\\n"

--- a/Racket.tmLanguage
+++ b/Racket.tmLanguage
@@ -131,7 +131,13 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(0|([1-9][0-9_]*))\b</string>
+			<string>\b(0|([1-9][0-9]*))\.([0-9]+)\b</string>
+			<key>name</key>
+			<string>constant.numeric.float.source.racket</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>\b(0|([1-9][0-9_]*))</string>
 			<key>name</key>
 			<string>constant.numeric.integer.source.racket</string>
 		</dict>


### PR DESCRIPTION
Hi,

I added a small definition for floats or at least for "numbers with dots in them" to be highlighted as constants. Maybe you can use it?

Best
David